### PR TITLE
Complete renaming + add package.json

### DIFF
--- a/MMM-Facts.js
+++ b/MMM-Facts.js
@@ -1,4 +1,4 @@
-Module.register("facts",{
+Module.register("MMM-Facts",{
 
 	// edit these
 	defaults: {

--- a/README.md
+++ b/README.md
@@ -1,39 +1,45 @@
-# Facts: A Magic Mirror Module
+# MMM-Facts: A MagicMirror Module
 
-Displays some facts. Makes your mirror look like an RPG loading screen. No APIs needed. 
+Displays some facts. Makes your mirror look like an RPG loading screen. No APIs needed.
 
 ![Example](example.png "Example")
 
 ## Installing the module
-Clone this repository in your `~/MagicMirror/modules/` folder
-````javascript
-git clone https://github.com/alanshen111/facts.git
-````
+
+Clone this repository in your `~/MagicMirror/modules/` folder:
+
+```bash
+git clone https://github.com/alanshen111/MMM-Facts
+```
 
 ## Using the module
+
 Add the module to the `~/MagicMirror/config/config.js` file:
-````javascript
+
+```javascript
 modules: [
 		{
-			module: 'facts',
+			module: 'MMM-Facts',
 			position: 'bottom_bar',
 		}
 ]
-````
+```
+
 You may also add configurations:
-````javascript
+
+```javascript
 modules: [
 		{
-			module: 'facts',
+			module: 'MMM-Facts',
 			position: 'bottom_bar',
 			config: {
-					updateInterval: 5,	
-					fadeSpeed: 4,			
-					category: 'random',	
+					updateInterval: 5,
+					fadeSpeed: 4,
+					category: 'random',
 			}
 		}
 ]
-````
+```
 
 ## Configuration options
 
@@ -61,5 +67,6 @@ modules: [
 </table>
 
 ## How to add your own facts
-You can edit the `facts.js` file, if you are comfortable merging them with any remote changes.
+
+You can edit the `MMM-Facts.js` file, if you are comfortable merging them with any remote changes.
 Alternatively, you may fork this repository to have an exclusive copy you can edit without conflicts.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "mmm-facts",
+  "version": "1.0.0",
+  "description": "Module for MagicMirror² to displays some interesting facts. Makes your mirror look like an RPG loading screen.",
+  "main": "MMM-Facts.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alanshen111/MMM-Facts.git"
+  },
+  "keywords": [
+    "MagicMirror",
+    "facts"
+  ],
+  "author": "Alan Shen",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/alanshen111/MMM-Facts/issues"
+  },
+  "homepage": "https://github.com/alanshen111/MMM-Facts#readme"
+}


### PR DESCRIPTION
Without the complete renaming, the module cannot be used by new users.

The package.json is mainly used to specify keywords for [the new module list](https://kristjanesperanto.github.io/MagicMirror-3rd-Party-Modules/).